### PR TITLE
处理_u._在传入内容为Number时，template的解析异常

### DIFF
--- a/src/base/util.js
+++ b/src/base/util.js
@@ -501,6 +501,7 @@ NEJ.define([
                 '"':'&quot;',"'":'&#39;','\n':'<br/>','\r':''
             };
         return function(_content){
+            _content += '';
             _content = _p._$encode(_map,_content);
             return _content.replace(_reg,'<br/><br/>');
         };


### PR DESCRIPTION
JST 模板解析时，对数字进行escape 时报错处理