### PR TITLE
update: regularModule add __doBuild function, and can assign __export info

### DIFF
--- a/src/util/dispatcher/regularModule.js
+++ b/src/util/dispatcher/regularModule.js
@@ -29,7 +29,15 @@ NEJ.define([
      */
     _pro.__build = function(){
         this._$innerModule = new this._$$InnerModule().$inject(this.__body);
-        this.__export.parent = this._$innerModule.$refs.view;
+
+        this._$innerModule.__export = {};
+        if (this._$innerModule.__doBuild) {
+            this._$innerModule.__doBuild();
+            this._$innerModule.$update();
+        }
+        this.__export = _u._$merge({
+            parent: this._$innerModule.$refs.view
+        }, this._$innerModule.__export);
 
         this._$innerModule.__doSendMessage = this.__doSendMessage._$bind(this);
     }


### PR DESCRIPTION
现在的regularModule无法设置`__export`属性，以指定子模块容器，即失去了私有模块的功能。本PR即添加该功能。

添加过程中有考虑过允许regularModule子类直接在声明、或config方法中直接指定子模块容器。但根据Regular的生命周期，在config方法执行完后，才有初始化的DOM元素。因此只能在init方法以及之后进行。

然后看到regularModule的父类`_$$ModuleAbstract`的代码，组合模块的逻辑在`__onShow`和`__onRefresh`时[调用](https://github.com/shhider/NEJ/blob/master/src/util/dispatcher/module.js#L231)；而regularModule中`__onShow`和`__onRefresh`中[先执行](https://github.com/shhider/NEJ/blob/master/src/util/dispatcher/regularModule.js#L63)了父方法。因此使用时在`__onShow`和`__onRefresh`时指定也不行。

所以只能放目光放在regularModule的`__build`方法，并结合NEJ模块的风格，向regularModule子类提供了`__doBuild`方法，在该方法中可以指定子模块容器和其他开放信息（即`__export`）。具体逻辑可见代码。
